### PR TITLE
enforce extension capability declarations via SecurityScanner integration (closes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.2.9] - 2026-03-31
+
+### Added
+- `Legion::Rbac::CapabilityAudit` module: static analysis of extension source code to detect dangerous patterns (`system`, `exec`, `Open3`, backticks, `eval`, `Net::HTTP`, `Faraday`, `File.write`, `FileUtils`) and map them to required capabilities (`shell_execute`, `code_eval`, `network_outbound`, `filesystem_write`). Blocks extensions with undeclared capabilities in enforce mode, warns in warn mode. Configurable via `rbac.capability_audit` settings.
+- `Legion::Rbac::CapabilityAudit::AuditResult` value object with `blocked?`, `undeclared`, `detected_capabilities`, `declared_capabilities`, and `to_h` conversion.
+- `Legion::Rbac::CapabilityRegistry` module: thread-safe registry tracking which extensions have which capabilities. `register`, `for_extension`, `extensions_with`, `audit_result_for`, `all`, `registered?`, `clear!` methods.
+- `Legion::Rbac::PolicyEngine.evaluate_capability`: runtime RBAC gating for capabilities — checks if a principal's roles grant or deny a specific capability, with deny-always-wins semantics and dry-run support.
+- `Legion::Rbac::Role#capability_allowed?`: per-role capability check (denial takes precedence over grant).
+- `capability_grants` and `capability_denials` fields on all four built-in roles: admin (all granted), supervisor (shell + network + filesystem, code_eval denied), worker (network + filesystem, shell + eval denied), governance-observer (all denied).
+- `Legion::Rbac.audit_extension`: convenience method that audits an extension and registers it in the CapabilityRegistry.
+- `Legion::Rbac.authorize_capability!`: raises `AccessDenied` when a principal lacks the required capability.
+- `rbac.capability_audit` settings: `enabled` (default true), `mode` (enforce/warn), `undeclared_policy` (block).
+- 43 new specs (159 total) covering all three phases of the capability enforcement system.
+
 ## [0.2.8] - 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Role-based access control for LegionIO, following Vault-style flat policy patterns.
 
-**Version**: 0.2.7
+**Version**: 0.2.9
 
 ## Features
 
@@ -51,6 +51,36 @@ principal.profile       # => { first_name: "Jane", last_name: "Doe", ... }
 
 ```ruby
 Legion::Rbac.authorize_execution!(principal: principal, runner_class: 'Legion::Extensions::LexHttp::Runners::Request', function: :get)
+```
+
+### Capability Audit (Extension Security)
+
+Audit an extension's source code for dangerous patterns and enforce capability declarations:
+
+```ruby
+result = Legion::Rbac.audit_extension(
+  extension_name: 'lex-codegen',
+  source_path: '/path/to/lex-codegen/lib',
+  declared_capabilities: [:shell_execute, :filesystem_write]
+)
+result.blocked?               # => false (all capabilities declared)
+result.detected_capabilities  # => [:shell_execute, :filesystem_write]
+
+# Query the capability registry
+Legion::Rbac::CapabilityRegistry.for_extension('lex-codegen')
+# => [:filesystem_write, :shell_execute]
+
+Legion::Rbac::CapabilityRegistry.extensions_with(:shell_execute)
+# => ["lex-codegen", "lex-exec"]
+```
+
+### Capability Authorization
+
+Check if a principal's role allows a specific capability:
+
+```ruby
+Legion::Rbac.authorize_capability!(principal: principal, capability: :shell_execute, extension_name: 'lex-codegen')
+# Raises AccessDenied if the principal's role denies shell_execute
 ```
 
 ### Dry-Run Check

--- a/lib/legion/rbac.rb
+++ b/lib/legion/rbac.rb
@@ -12,6 +12,8 @@ require 'legion/rbac/store'
 require 'legion/rbac/entra_claims_mapper'
 require 'legion/rbac/middleware'
 require 'legion/rbac/routes'
+require 'legion/rbac/capability_audit'
+require 'legion/rbac/capability_registry'
 
 module Legion
   module Rbac
@@ -58,6 +60,31 @@ module Legion
       def authorize_execution!(principal:, runner_class:, function:, **)
         runner_path = build_runner_path(runner_class, function)
         authorize!(principal: principal, action: :execute, resource: runner_path, **)
+      end
+
+      def audit_extension(extension_name:, source_path:, declared_capabilities: [])
+        result = CapabilityAudit.audit(
+          extension_name:        extension_name,
+          source_path:           source_path,
+          declared_capabilities: declared_capabilities
+        )
+        CapabilityRegistry.register(
+          extension_name,
+          capabilities: result.detected_capabilities,
+          audit_result: result
+        )
+        result
+      end
+
+      def authorize_capability!(principal:, capability:, extension_name: nil)
+        result = PolicyEngine.evaluate_capability(
+          principal:      principal,
+          capability:     capability,
+          extension_name: extension_name
+        )
+        raise AccessDenied, result unless result[:allowed]
+
+        result
       end
 
       private

--- a/lib/legion/rbac/capability_audit.rb
+++ b/lib/legion/rbac/capability_audit.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module Legion
+  module Rbac
+    module CapabilityAudit
+      PATTERN_TO_CAPABILITY = {
+        /\bKernel\.system\b|\bsystem\s*\(/     => :shell_execute,
+        /\bKernel\.exec\b|\bexec\s*\(/         => :shell_execute,
+        /\bOpen3\b/                            => :shell_execute,
+        /`[^`]+`/                              => :shell_execute,
+        /\bIO\.popen\b/                        => :shell_execute,
+        /\bKernel\.eval\b|\beval\s*\(/         => :code_eval,
+        /\bNet::HTTP\b/                        => :network_outbound,
+        /\bFaraday\b/                          => :network_outbound,
+        /\bHTTParty\b/                         => :network_outbound,
+        /\bFile\.(write|open|delete|rename)\b/ => :filesystem_write,
+        /\bFileUtils\b/                        => :filesystem_write
+      }.freeze
+
+      class AuditResult
+        attr_reader :extension_name, :detected_capabilities, :declared_capabilities,
+                    :undeclared, :allowed, :reason
+
+        def initialize(extension_name:, detected:, declared:, allowed:, reason: nil)
+          @extension_name = extension_name
+          @detected_capabilities = detected.uniq.sort
+          @declared_capabilities = declared.map(&:to_sym).uniq.sort
+          @undeclared = (@detected_capabilities - @declared_capabilities).sort
+          @allowed = allowed
+          @reason = reason
+        end
+
+        def blocked?
+          !@allowed
+        end
+
+        def to_h
+          hash = {
+            extension_name:        @extension_name,
+            allowed:               @allowed,
+            detected_capabilities: @detected_capabilities,
+            declared_capabilities: @declared_capabilities,
+            undeclared:            @undeclared
+          }
+          hash[:reason] = @reason if @reason
+          hash
+        end
+      end
+
+      class << self
+        def audit(extension_name:, source_path:, declared_capabilities: [])
+          return skip_result(extension_name, 'capability audit disabled') unless enabled?
+
+          return skip_result(extension_name, 'no source path') unless source_path && Dir.exist?(source_path.to_s)
+
+          detected = scan_source(source_path)
+          declared_syms = Array(declared_capabilities).map(&:to_sym)
+          undeclared = (detected.uniq - declared_syms)
+
+          if undeclared.empty?
+            AuditResult.new(
+              extension_name: extension_name,
+              detected:       detected,
+              declared:       declared_syms,
+              allowed:        true
+            )
+          else
+            handle_undeclared(extension_name, detected, declared_syms, undeclared)
+          end
+        end
+
+        def enabled?
+          settings = capability_audit_settings
+          settings[:enabled] != false
+        end
+
+        def mode
+          settings = capability_audit_settings
+          (settings[:mode] || 'enforce').to_s
+        end
+
+        private
+
+        def scan_source(source_path)
+          capabilities = []
+          Dir.glob(File.join(source_path, '**', '*.rb')).each do |file|
+            File.foreach(file) do |line|
+              PATTERN_TO_CAPABILITY.each do |pattern, capability|
+                capabilities << capability if line.match?(pattern)
+              end
+            end
+          end
+          capabilities.uniq
+        end
+
+        def handle_undeclared(extension_name, detected, declared, undeclared)
+          if mode == 'warn'
+            log_warning(extension_name, undeclared)
+            AuditResult.new(
+              extension_name: extension_name,
+              detected:       detected,
+              declared:       declared,
+              allowed:        true,
+              reason:         "undeclared capabilities (warn mode): #{undeclared.join(', ')}"
+            )
+          else
+            AuditResult.new(
+              extension_name: extension_name,
+              detected:       detected,
+              declared:       declared,
+              allowed:        false,
+              reason:         "undeclared capabilities: #{undeclared.join(', ')}"
+            )
+          end
+        end
+
+        def log_warning(extension_name, undeclared)
+          return unless defined?(Legion::Logging)
+
+          Legion::Logging.warn(
+            "CapabilityAudit: #{extension_name} uses undeclared capabilities: #{undeclared.join(', ')}"
+          )
+        end
+
+        def skip_result(extension_name, reason)
+          AuditResult.new(
+            extension_name: extension_name,
+            detected:       [],
+            declared:       [],
+            allowed:        true,
+            reason:         reason
+          )
+        end
+
+        def capability_audit_settings
+          return {} unless defined?(Legion::Settings)
+
+          Legion::Settings[:rbac]&.dig(:capability_audit) || {}
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/rbac/capability_registry.rb
+++ b/lib/legion/rbac/capability_registry.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'monitor'
+
+module Legion
+  module Rbac
+    module CapabilityRegistry
+      class << self
+        def register(extension_name, capabilities:, audit_result: nil)
+          mon.synchronize do
+            entries[extension_name.to_s] = {
+              capabilities:  Array(capabilities).map(&:to_sym).uniq,
+              audit_result:  audit_result,
+              registered_at: Time.now
+            }
+          end
+        end
+
+        def for_extension(extension_name)
+          mon.synchronize do
+            entry = entries[extension_name.to_s]
+            entry ? entry[:capabilities] : []
+          end
+        end
+
+        def extensions_with(capability)
+          cap_sym = capability.to_sym
+          mon.synchronize do
+            entries.select { |_, entry| entry[:capabilities].include?(cap_sym) }.keys
+          end
+        end
+
+        def audit_result_for(extension_name)
+          mon.synchronize do
+            entry = entries[extension_name.to_s]
+            entry&.dig(:audit_result)
+          end
+        end
+
+        def all
+          mon.synchronize { entries.dup }
+        end
+
+        def registered?(extension_name)
+          mon.synchronize { entries.key?(extension_name.to_s) }
+        end
+
+        def clear!
+          mon.synchronize { @entries = {} }
+        end
+
+        private
+
+        def entries
+          @entries ||= {}
+        end
+
+        def mon
+          @mon ||= Monitor.new
+        end
+      end
+    end
+  end
+end

--- a/lib/legion/rbac/config_loader.rb
+++ b/lib/legion/rbac/config_loader.rb
@@ -9,11 +9,13 @@ module Legion
         roles_config ||= Legion::Settings[:rbac][:roles]
         roles_config.each_with_object({}) do |(name, config), index|
           index[name.to_sym] = Role.new(
-            name:        name,
-            description: config[:description] || '',
-            permissions: config[:permissions] || [],
-            deny:        config[:deny] || [],
-            cross_team:  config[:cross_team] || false
+            name:               name,
+            description:        config[:description] || '',
+            permissions:        config[:permissions] || [],
+            deny:               config[:deny] || [],
+            cross_team:         config[:cross_team] || false,
+            capability_grants:  config[:capability_grants] || [],
+            capability_denials: config[:capability_denials] || []
           )
         end
       end

--- a/lib/legion/rbac/policy_engine.rb
+++ b/lib/legion/rbac/policy_engine.rb
@@ -49,6 +49,44 @@ module Legion
         end
       end
 
+      def self.evaluate_capability(principal:, capability:, extension_name: nil, role_index: nil, enforce: nil)
+        role_index ||= Legion::Rbac.role_index || {}
+        enforce = Legion::Settings[:rbac][:enforce] if enforce.nil?
+
+        resolved_roles = resolve_roles(principal, role_index)
+
+        if resolved_roles.empty?
+          return build_capability_result(
+            allowed: false, reason: 'no roles assigned',
+            principal: principal, capability: capability,
+            extension_name: extension_name, enforce: enforce
+          )
+        end
+
+        denied = resolved_roles.any? { |role| role.capability_denials.include?(capability.to_sym) }
+        if denied
+          return build_capability_result(
+            allowed: false, reason: "capability #{capability} denied by role policy",
+            principal: principal, capability: capability,
+            extension_name: extension_name, enforce: enforce
+          )
+        end
+
+        granted = resolved_roles.any? { |role| role.capability_grants.include?(capability.to_sym) }
+        unless granted
+          return build_capability_result(
+            allowed: false, reason: "capability #{capability} not granted by any role",
+            principal: principal, capability: capability,
+            extension_name: extension_name, enforce: enforce
+          )
+        end
+
+        build_capability_result(
+          allowed: true, principal: principal, capability: capability,
+          extension_name: extension_name, enforce: enforce
+        )
+      end
+
       def self.build_result(allowed:, principal:, action:, resource:, enforce:, reason: nil)
         result = {
           allowed:      enforce ? allowed : true,
@@ -56,6 +94,18 @@ module Legion
           resource:     resource,
           principal_id: principal.id
         }
+        result[:reason] = reason if reason
+        result[:would_deny] = true if !enforce && !allowed
+        result
+      end
+
+      def self.build_capability_result(allowed:, principal:, capability:, enforce:, extension_name: nil, reason: nil)
+        result = {
+          allowed:      enforce ? allowed : true,
+          capability:   capability.to_s,
+          principal_id: principal.id
+        }
+        result[:extension_name] = extension_name if extension_name
         result[:reason] = reason if reason
         result[:would_deny] = true if !enforce && !allowed
         result

--- a/lib/legion/rbac/role.rb
+++ b/lib/legion/rbac/role.rb
@@ -5,9 +5,11 @@ require 'legion/rbac/permission'
 module Legion
   module Rbac
     class Role
-      attr_reader :name, :description, :permissions, :deny_rules, :cross_team
+      attr_reader :name, :description, :permissions, :deny_rules, :cross_team,
+                  :capability_grants, :capability_denials
 
-      def initialize(name:, description: '', permissions: [], deny: [], cross_team: false)
+      def initialize(name:, description: '', permissions: [], deny: [], cross_team: false,
+                     capability_grants: [], capability_denials: [])
         @name = name.to_s
         @description = description
         @permissions = permissions.map do |p|
@@ -17,10 +19,19 @@ module Legion
           DenyRule.new(resource_pattern: d[:resource], above_level: d[:above_level])
         end
         @cross_team = cross_team
+        @capability_grants = Array(capability_grants).map(&:to_sym)
+        @capability_denials = Array(capability_denials).map(&:to_sym)
       end
 
       def cross_team?
         @cross_team == true
+      end
+
+      def capability_allowed?(capability)
+        cap = capability.to_sym
+        return false if @capability_denials.include?(cap)
+
+        @capability_grants.include?(cap)
       end
     end
   end

--- a/lib/legion/rbac/settings.rb
+++ b/lib/legion/rbac/settings.rb
@@ -12,7 +12,16 @@ module Legion
           static_assignments: [],
           route_permissions:  {},
           roles:              default_roles,
-          entra:              entra_defaults
+          entra:              entra_defaults,
+          capability_audit:   capability_audit_defaults
+        }
+      end
+
+      def self.capability_audit_defaults
+        {
+          enabled:           true,
+          mode:              'enforce',
+          undeclared_policy: 'block'
         }
       end
 
@@ -41,25 +50,27 @@ module Legion
 
       def self.worker_role
         {
-          description: 'Execute assigned runners within team scope',
-          permissions: [
+          description:        'Execute assigned runners within team scope',
+          permissions:        [
             { resource: 'runners/*', actions: %w[execute] },
             { resource: 'tasks/*', actions: %w[read create] },
             { resource: 'schedules/*', actions: %w[read] },
             { resource: 'workers/self', actions: %w[read] }
           ],
-          deny:        [
+          deny:               [
             { resource: 'runners/lex-extinction/*' },
             { resource: 'runners/lex-governance/*' },
             { resource: 'workers/*/lifecycle' }
-          ]
+          ],
+          capability_grants:  %w[network_outbound filesystem_write],
+          capability_denials: %w[shell_execute code_eval]
         }
       end
 
       def self.supervisor_role
         {
-          description: 'Manage workers and schedules within team scope',
-          permissions: [
+          description:        'Manage workers and schedules within team scope',
+          permissions:        [
             { resource: 'runners/*', actions: %w[execute] },
             { resource: 'tasks/*', actions: %w[read create delete] },
             { resource: 'schedules/*', actions: %w[read create update delete] },
@@ -67,28 +78,32 @@ module Legion
             { resource: 'extensions/*', actions: %w[read] },
             { resource: 'events/*', actions: %w[read] }
           ],
-          deny:        [
+          deny:               [
             { resource: 'runners/lex-extinction/escalate', above_level: 2 },
             { resource: 'workers/*/lifecycle/terminated' }
-          ]
+          ],
+          capability_grants:  %w[network_outbound filesystem_write shell_execute],
+          capability_denials: %w[code_eval]
         }
       end
 
       def self.admin_role
         {
-          description: 'Full access, cross-team capability',
-          permissions: [
+          description:        'Full access, cross-team capability',
+          permissions:        [
             { resource: '*', actions: %w[read create update delete execute manage] }
           ],
-          deny:        [],
-          cross_team:  true
+          deny:               [],
+          cross_team:         true,
+          capability_grants:  %w[shell_execute code_eval network_outbound filesystem_write],
+          capability_denials: []
         }
       end
 
       def self.governance_observer_role
         {
-          description: 'Read-only visibility across all teams for audit and compliance',
-          permissions: [
+          description:        'Read-only visibility across all teams for audit and compliance',
+          permissions:        [
             { resource: 'workers/*', actions: %w[read] },
             { resource: 'tasks/*', actions: %w[read] },
             { resource: 'events/*', actions: %w[read] },
@@ -96,8 +111,10 @@ module Legion
             { resource: 'extensions/*', actions: %w[read] },
             { resource: 'runners/lex-governance/*', actions: %w[read execute] }
           ],
-          deny:        [],
-          cross_team:  true
+          deny:               [],
+          cross_team:         true,
+          capability_grants:  [],
+          capability_denials: %w[shell_execute code_eval network_outbound filesystem_write]
         }
       end
     end

--- a/lib/legion/rbac/version.rb
+++ b/lib/legion/rbac/version.rb
@@ -2,6 +2,6 @@
 
 module Legion
   module Rbac
-    VERSION = '0.2.8'
+    VERSION = '0.2.9'
   end
 end

--- a/spec/legion/rbac/capability_audit_spec.rb
+++ b/spec/legion/rbac/capability_audit_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe Legion::Rbac::CapabilityAudit do
+  let(:tmpdir) { Dir.mktmpdir('cap-audit') }
+
+  after do
+    FileUtils.remove_entry(tmpdir)
+    Legion::Settings[:rbac][:capability_audit][:mode] = 'enforce'
+    Legion::Settings[:rbac][:capability_audit][:enabled] = true
+  end
+
+  def write_source(filename, content)
+    File.write(File.join(tmpdir, filename), content)
+  end
+
+  describe '.audit' do
+    context 'when source contains system() without declaring shell_execute' do
+      before { write_source('runner.rb', "system('ls -la')") }
+
+      it 'blocks the extension in enforce mode' do
+        Legion::Settings[:rbac][:capability_audit][:mode] = 'enforce'
+        result = described_class.audit(
+          extension_name:        'lex-danger',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.blocked?).to be true
+        expect(result.undeclared).to eq([:shell_execute])
+        expect(result.reason).to include('undeclared capabilities')
+      end
+
+      it 'allows with warning in warn mode' do
+        Legion::Settings[:rbac][:capability_audit][:mode] = 'warn'
+        result = described_class.audit(
+          extension_name:        'lex-danger',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.blocked?).to be false
+        expect(result.reason).to include('warn mode')
+      end
+    end
+
+    context 'when source contains exec() with shell_execute declared' do
+      before { write_source('runner.rb', "Kernel.exec('bin/start')") }
+
+      it 'allows the extension' do
+        result = described_class.audit(
+          extension_name:        'lex-runner',
+          source_path:           tmpdir,
+          declared_capabilities: [:shell_execute]
+        )
+        expect(result.blocked?).to be false
+        expect(result.undeclared).to be_empty
+      end
+    end
+
+    context 'when source contains eval()' do
+      before { write_source('dynamic.rb', 'eval(some_code)') }
+
+      it 'detects code_eval capability' do
+        result = described_class.audit(
+          extension_name:        'lex-dynamic',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:code_eval)
+        expect(result.blocked?).to be true
+      end
+    end
+
+    context 'when source contains Open3' do
+      before { write_source('shell.rb', "Open3.capture3('ls')") }
+
+      it 'detects shell_execute capability' do
+        result = described_class.audit(
+          extension_name:        'lex-shell',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:shell_execute)
+      end
+    end
+
+    context 'when source contains backtick subshell' do
+      before { write_source('cmd.rb', 'output = `whoami`') }
+
+      it 'detects shell_execute capability' do
+        result = described_class.audit(
+          extension_name:        'lex-cmd',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:shell_execute)
+      end
+    end
+
+    context 'when source contains IO.popen' do
+      before { write_source('io.rb', "IO.popen('cat', 'r')") }
+
+      it 'detects shell_execute capability' do
+        result = described_class.audit(
+          extension_name:        'lex-io',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:shell_execute)
+      end
+    end
+
+    context 'when source contains Net::HTTP' do
+      before { write_source('http.rb', 'Net::HTTP.get(uri)') }
+
+      it 'detects network_outbound capability' do
+        result = described_class.audit(
+          extension_name:        'lex-http',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:network_outbound)
+      end
+    end
+
+    context 'when source contains Faraday' do
+      before { write_source('api.rb', 'Faraday.get(url)') }
+
+      it 'detects network_outbound capability' do
+        result = described_class.audit(
+          extension_name:        'lex-api',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:network_outbound)
+      end
+    end
+
+    context 'when source contains File.write' do
+      before { write_source('writer.rb', "File.write('/tmp/out.txt', data)") }
+
+      it 'detects filesystem_write capability' do
+        result = described_class.audit(
+          extension_name:        'lex-writer',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:filesystem_write)
+      end
+    end
+
+    context 'when source contains FileUtils' do
+      before { write_source('files.rb', 'FileUtils.cp(src, dst)') }
+
+      it 'detects filesystem_write capability' do
+        result = described_class.audit(
+          extension_name:        'lex-files',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:filesystem_write)
+      end
+    end
+
+    context 'when source is clean' do
+      before { write_source('safe.rb', "puts 'hello world'") }
+
+      it 'allows the extension with no capabilities detected' do
+        result = described_class.audit(
+          extension_name:        'lex-safe',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.blocked?).to be false
+        expect(result.detected_capabilities).to be_empty
+      end
+    end
+
+    context 'when source has multiple patterns' do
+      before do
+        write_source('multi.rb', <<~RUBY)
+          system('deploy')
+          Net::HTTP.get(uri)
+          eval(code)
+        RUBY
+      end
+
+      it 'detects all capabilities' do
+        result = described_class.audit(
+          extension_name:        'lex-multi',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to contain_exactly(:code_eval, :network_outbound, :shell_execute)
+      end
+
+      it 'passes when all capabilities are declared' do
+        result = described_class.audit(
+          extension_name:        'lex-multi',
+          source_path:           tmpdir,
+          declared_capabilities: %i[shell_execute network_outbound code_eval]
+        )
+        expect(result.blocked?).to be false
+        expect(result.undeclared).to be_empty
+      end
+    end
+
+    context 'when source_path does not exist' do
+      it 'returns allowed with skip reason' do
+        result = described_class.audit(
+          extension_name:        'lex-missing',
+          source_path:           '/nonexistent/path',
+          declared_capabilities: []
+        )
+        expect(result.blocked?).to be false
+        expect(result.reason).to eq('no source path')
+      end
+    end
+
+    context 'when capability audit is disabled' do
+      before { Legion::Settings[:rbac][:capability_audit][:enabled] = false }
+
+      after { Legion::Settings[:rbac][:capability_audit][:enabled] = true }
+
+      it 'returns allowed with skip reason' do
+        write_source('danger.rb', "system('rm -rf /')")
+        result = described_class.audit(
+          extension_name:        'lex-danger',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.blocked?).to be false
+        expect(result.reason).to eq('capability audit disabled')
+      end
+    end
+
+    context 'with nested source files' do
+      before do
+        nested = File.join(tmpdir, 'lib', 'runners')
+        FileUtils.mkdir_p(nested)
+        File.write(File.join(nested, 'deep.rb'), "system('deploy')")
+      end
+
+      it 'scans recursively' do
+        result = described_class.audit(
+          extension_name:        'lex-nested',
+          source_path:           tmpdir,
+          declared_capabilities: []
+        )
+        expect(result.detected_capabilities).to include(:shell_execute)
+      end
+    end
+  end
+
+  describe '.enabled?' do
+    it 'returns true by default' do
+      expect(described_class.enabled?).to be true
+    end
+
+    it 'returns false when disabled' do
+      Legion::Settings[:rbac][:capability_audit][:enabled] = false
+      expect(described_class.enabled?).to be false
+      Legion::Settings[:rbac][:capability_audit][:enabled] = true
+    end
+  end
+
+  describe '.mode' do
+    it 'defaults to enforce' do
+      expect(described_class.mode).to eq('enforce')
+    end
+
+    it 'reads from settings' do
+      Legion::Settings[:rbac][:capability_audit][:mode] = 'warn'
+      expect(described_class.mode).to eq('warn')
+      Legion::Settings[:rbac][:capability_audit][:mode] = 'enforce'
+    end
+  end
+
+  describe 'AuditResult' do
+    subject(:result) do
+      described_class::AuditResult.new(
+        extension_name: 'lex-test',
+        detected:       %i[shell_execute network_outbound],
+        declared:       [:shell_execute],
+        allowed:        false,
+        reason:         'undeclared capabilities: network_outbound'
+      )
+    end
+
+    it 'tracks undeclared capabilities' do
+      expect(result.undeclared).to eq([:network_outbound])
+    end
+
+    it 'converts to hash' do
+      hash = result.to_h
+      expect(hash[:extension_name]).to eq('lex-test')
+      expect(hash[:allowed]).to be false
+      expect(hash[:reason]).to include('network_outbound')
+    end
+  end
+end

--- a/spec/legion/rbac/capability_policy_spec.rb
+++ b/spec/legion/rbac/capability_policy_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+
+RSpec.describe Legion::Rbac::PolicyEngine, '.evaluate_capability' do
+  let(:role_index) { Legion::Rbac::ConfigLoader.load_roles }
+
+  def principal_with(roles:)
+    Legion::Rbac::Principal.new(id: 'test', roles: roles)
+  end
+
+  context 'admin role' do
+    it 'grants shell_execute' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['admin']),
+        capability: :shell_execute,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be true
+    end
+
+    it 'grants code_eval' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['admin']),
+        capability: :code_eval,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be true
+    end
+  end
+
+  context 'worker role' do
+    it 'grants network_outbound' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['worker']),
+        capability: :network_outbound,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be true
+    end
+
+    it 'denies shell_execute' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['worker']),
+        capability: :shell_execute,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be false
+      expect(result[:reason]).to include('denied by role policy')
+    end
+
+    it 'denies code_eval' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['worker']),
+        capability: :code_eval,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be false
+      expect(result[:reason]).to include('denied by role policy')
+    end
+  end
+
+  context 'supervisor role' do
+    it 'grants shell_execute' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['supervisor']),
+        capability: :shell_execute,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be true
+    end
+
+    it 'denies code_eval' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['supervisor']),
+        capability: :code_eval,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be false
+    end
+  end
+
+  context 'governance-observer role' do
+    it 'denies all capabilities' do
+      %i[shell_execute code_eval network_outbound filesystem_write].each do |cap|
+        result = described_class.evaluate_capability(
+          principal:  principal_with(roles: ['governance-observer']),
+          capability: cap,
+          role_index: role_index
+        )
+        expect(result[:allowed]).to be false
+      end
+    end
+  end
+
+  context 'no roles' do
+    it 'denies with no roles assigned reason' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: []),
+        capability: :shell_execute,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be false
+      expect(result[:reason]).to eq('no roles assigned')
+    end
+  end
+
+  context 'enforce: false' do
+    it 'returns allowed: true with would_deny flag' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['worker']),
+        capability: :shell_execute,
+        role_index: role_index,
+        enforce:    false
+      )
+      expect(result[:allowed]).to be true
+      expect(result[:would_deny]).to be true
+    end
+  end
+
+  context 'with extension_name' do
+    it 'includes extension_name in result' do
+      result = described_class.evaluate_capability(
+        principal:      principal_with(roles: ['admin']),
+        capability:     :shell_execute,
+        extension_name: 'lex-codegen',
+        role_index:     role_index
+      )
+      expect(result[:extension_name]).to eq('lex-codegen')
+    end
+  end
+
+  context 'capability not granted and not denied' do
+    it 'reports not granted' do
+      result = described_class.evaluate_capability(
+        principal:  principal_with(roles: ['worker']),
+        capability: :some_unknown_cap,
+        role_index: role_index
+      )
+      expect(result[:allowed]).to be false
+      expect(result[:reason]).to include('not granted')
+    end
+  end
+end
+
+RSpec.describe Legion::Rbac do
+  before { described_class.setup }
+
+  describe '.audit_extension' do
+    let(:tmpdir) { Dir.mktmpdir('audit-ext') }
+
+    after do
+      FileUtils.remove_entry(tmpdir)
+      Legion::Rbac::CapabilityRegistry.clear!
+    end
+
+    it 'audits and registers in capability registry' do
+      File.write(File.join(tmpdir, 'runner.rb'), "system('deploy')")
+      result = described_class.audit_extension(
+        extension_name:        'lex-deployer',
+        source_path:           tmpdir,
+        declared_capabilities: [:shell_execute]
+      )
+      expect(result.blocked?).to be false
+      expect(Legion::Rbac::CapabilityRegistry.for_extension('lex-deployer')).to include(:shell_execute)
+    end
+
+    it 'blocks undeclared capabilities in enforce mode' do
+      # Test file contains a dangerous pattern (Kernel.eval) without declaration
+      File.write(File.join(tmpdir, 'runner.rb'), 'Kernel.eval(code)')
+      result = described_class.audit_extension(
+        extension_name:        'lex-bad',
+        source_path:           tmpdir,
+        declared_capabilities: []
+      )
+      expect(result.blocked?).to be true
+    end
+  end
+
+  describe '.authorize_capability!' do
+    it 'raises AccessDenied when capability is denied' do
+      principal = Legion::Rbac::Principal.new(id: 'worker-1', roles: ['worker'])
+      expect do
+        described_class.authorize_capability!(principal: principal, capability: :shell_execute)
+      end.to raise_error(Legion::Rbac::AccessDenied)
+    end
+
+    it 'returns result when capability is granted' do
+      principal = Legion::Rbac::Principal.new(id: 'admin-1', roles: ['admin'])
+      result = described_class.authorize_capability!(principal: principal, capability: :shell_execute)
+      expect(result[:allowed]).to be true
+    end
+  end
+end
+
+RSpec.describe Legion::Rbac::Role do
+  describe '#capability_allowed?' do
+    it 'returns true for granted capability' do
+      role = described_class.new(
+        name:              'deployer',
+        capability_grants: %w[shell_execute network_outbound]
+      )
+      expect(role.capability_allowed?(:shell_execute)).to be true
+    end
+
+    it 'returns false for denied capability' do
+      role = described_class.new(
+        name:               'restricted',
+        capability_grants:  %w[shell_execute],
+        capability_denials: %w[code_eval]
+      )
+      expect(role.capability_allowed?(:code_eval)).to be false
+    end
+
+    it 'returns false for ungranted capability' do
+      role = described_class.new(name: 'basic', capability_grants: %w[network_outbound])
+      expect(role.capability_allowed?(:shell_execute)).to be false
+    end
+
+    it 'denial takes precedence over grant' do
+      role = described_class.new(
+        name:               'conflicted',
+        capability_grants:  %w[shell_execute],
+        capability_denials: %w[shell_execute]
+      )
+      expect(role.capability_allowed?(:shell_execute)).to be false
+    end
+  end
+end

--- a/spec/legion/rbac/capability_registry_spec.rb
+++ b/spec/legion/rbac/capability_registry_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+RSpec.describe Legion::Rbac::CapabilityRegistry do
+  before { described_class.clear! }
+
+  describe '.register and .for_extension' do
+    it 'stores and retrieves capabilities for an extension' do
+      described_class.register('lex-codegen', capabilities: %i[shell_execute filesystem_write])
+      expect(described_class.for_extension('lex-codegen')).to contain_exactly(:shell_execute, :filesystem_write)
+    end
+
+    it 'returns empty array for unknown extension' do
+      expect(described_class.for_extension('lex-unknown')).to eq([])
+    end
+
+    it 'deduplicates capabilities' do
+      described_class.register('lex-dup', capabilities: %i[shell_execute shell_execute network_outbound])
+      expect(described_class.for_extension('lex-dup')).to contain_exactly(:shell_execute, :network_outbound)
+    end
+
+    it 'stores audit_result when provided' do
+      audit = instance_double(Legion::Rbac::CapabilityAudit::AuditResult)
+      described_class.register('lex-audited', capabilities: [:shell_execute], audit_result: audit)
+      expect(described_class.audit_result_for('lex-audited')).to eq(audit)
+    end
+  end
+
+  describe '.extensions_with' do
+    before do
+      described_class.register('lex-exec', capabilities: [:shell_execute])
+      described_class.register('lex-codegen', capabilities: %i[shell_execute filesystem_write])
+      described_class.register('lex-http', capabilities: [:network_outbound])
+    end
+
+    it 'returns extensions with the given capability' do
+      expect(described_class.extensions_with(:shell_execute)).to contain_exactly('lex-exec', 'lex-codegen')
+    end
+
+    it 'returns empty for unmatched capability' do
+      expect(described_class.extensions_with(:code_eval)).to eq([])
+    end
+  end
+
+  describe '.all' do
+    it 'returns all registered entries' do
+      described_class.register('lex-a', capabilities: [:shell_execute])
+      described_class.register('lex-b', capabilities: [:network_outbound])
+      expect(described_class.all.keys).to contain_exactly('lex-a', 'lex-b')
+    end
+  end
+
+  describe '.registered?' do
+    it 'returns true for registered extensions' do
+      described_class.register('lex-known', capabilities: [])
+      expect(described_class.registered?('lex-known')).to be true
+    end
+
+    it 'returns false for unknown extensions' do
+      expect(described_class.registered?('lex-unknown')).to be false
+    end
+  end
+
+  describe '.clear!' do
+    it 'removes all entries' do
+      described_class.register('lex-temp', capabilities: [:shell_execute])
+      described_class.clear!
+      expect(described_class.all).to be_empty
+    end
+  end
+
+  describe '.audit_result_for' do
+    it 'returns nil for unregistered extension' do
+      expect(described_class.audit_result_for('lex-missing')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Three-phase capability enforcement connecting SecurityScanner, Sandbox, and RBAC
- Phase 1: `CapabilityAudit` scans extension source for 11 dangerous patterns, maps to 4 capabilities, blocks undeclared in enforce mode
- Phase 2: `PolicyEngine.evaluate_capability` gates runtime access via role `capability_grants`/`capability_denials` (deny-always-wins)
- Phase 3: `CapabilityRegistry` thread-safe registry tracking per-extension capabilities with query API

## Test plan
- [x] 159 specs passing (43 new), 0 failures
- [x] 0 rubocop offenses
- [x] Version bumped to 0.2.9
- [x] CHANGELOG updated
- [x] README updated with capability audit and authorization examples